### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Vue.component('parallax-element', ParallaxElement)
 
 # Usage
 
-In order for the effect to work, the <parallax-element /> should be contained within <parallax-container />
+In order for the effect to work, the `<parallax-element />` should be contained within <parallax-container />
 
-Options can then be passed to <parallax-element /> like so :
+Options can then be passed to `<parallax-element />` like so :
 
 ```html
 // App.vue


### PR DESCRIPTION
The `<parallax-element />` tag was missing (certainly due to the way github handles raw html tags in md files)