### PR TITLE
use provide/inject instead this.parent for expose the context to a child component

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,9 @@ Options can then be passed to `<parallax-element />` like so :
 
 ```html
 <parallax-container>
-    <template v-slot="{ context }">
-        <parallax-element
-            :context="context"
-            :parallaxStrength="10"
-            type="translation"
-            tag="div">
-            <h2>Put your content here</h2>
-        </parallax-element>
-    </template>
+    <parallax-element :parallaxStrength="10" type="translation" tag="div">
+        <h2>Put your content here</h2>
+     </parallax-element>
 </parallax-container>
 ```
 
@@ -79,7 +73,6 @@ Options can then be passed to `<parallax-element />` like so :
 ### parallax-element
 | Prop   |      Type      |  Default Value | Description
 |----------|:-------------:|------|------|
-| context |  Object | mousePosition, isHovering, isHovering, didEnter, animationDuration, easing, shape | passing parent context |
 | parallaxStrength |  Number | 10 | Strength of the Parallax Effect |
 | type |  String   | 'translation' | 'translation' - 'rotation' - 'depth' |
 | tag |  String   | div | Takes any valid html tag |

--- a/README.md
+++ b/README.md
@@ -53,9 +53,15 @@ Options can then be passed to `<parallax-element />` like so :
 
 ```html
 <parallax-container>
-    <parallax-element :parallaxStrength="10" type="translation" tag="div">
-        <h2>Put your content here</h2>
-     </parallax-element>
+    <template v-slot="{ context }">
+        <parallax-element
+            :context="context"
+            :parallaxStrength="10"
+            type="translation"
+            tag="div">
+            <h2>Put your content here</h2>
+        </parallax-element>
+    </template>
 </parallax-container>
 ```
 
@@ -73,6 +79,7 @@ Options can then be passed to `<parallax-element />` like so :
 ### parallax-element
 | Prop   |      Type      |  Default Value | Description
 |----------|:-------------:|------|------|
+| context |  Object | mousePosition, isHovering, isHovering, didEnter, animationDuration, easing, shape | passing parent context |
 | parallaxStrength |  Number | 10 | Strength of the Parallax Effect |
 | type |  String   | 'translation' | 'translation' - 'rotation' - 'depth' |
 | tag |  String   | div | Takes any valid html tag |

--- a/src/components/parallax-container.vue
+++ b/src/components/parallax-container.vue
@@ -25,7 +25,7 @@ export default {
 
     Object.defineProperty(context, 'isHovering', {
       enumerable: true,
-      get: () => this.isHoverable,
+      get: () => this.isHovering,
     });
 
     Object.defineProperty(context, 'isHoverable', {

--- a/src/components/parallax-container.vue
+++ b/src/components/parallax-container.vue
@@ -6,7 +6,16 @@
     @mouseenter="parallaxStart"
     :style="{perspective: `${perspective}px`}"
   >
-    <slot></slot>
+    <slot :context="{
+      mousePosition,
+      isHovering,
+      isHoverable,
+      didEnter,
+      animationDuration,
+      easing,
+      shape,
+      }">
+    </slot>
   </component>
 </template>
 
@@ -25,6 +34,7 @@ export default {
       isHoverable: false,
       attemptedHover: false,
       didEnter: false,
+      shape: null,
     };
   },
   props: {
@@ -46,6 +56,7 @@ export default {
     },
   },
   mounted() {
+    this.shape = this.$el.getBoundingClientRect();
     setTimeout(() => {
       this.isHoverable = true;
       if (this.attemptedHover) {

--- a/src/components/parallax-container.vue
+++ b/src/components/parallax-container.vue
@@ -6,16 +6,7 @@
     @mouseenter="parallaxStart"
     :style="{perspective: `${perspective}px`}"
   >
-    <slot :context="{
-      mousePosition,
-      isHovering,
-      isHoverable,
-      didEnter,
-      animationDuration,
-      easing,
-      shape,
-      }">
-    </slot>
+    <slot></slot>
   </component>
 </template>
 
@@ -24,6 +15,46 @@ import throttle from '../lib/throttle';
 
 export default {
   name: 'ParallaxContainer',
+  provide() {
+    const context = {};
+
+    Object.defineProperty(context, 'mousePosition', {
+      enumerable: true,
+      get: () => this.mousePosition,
+    });
+
+    Object.defineProperty(context, 'isHovering', {
+      enumerable: true,
+      get: () => this.isHoverable,
+    });
+
+    Object.defineProperty(context, 'isHoverable', {
+      enumerable: true,
+      get: () => this.isHoverable,
+    });
+
+    Object.defineProperty(context, 'didEnter', {
+      enumerable: true,
+      get: () => this.didEnter,
+    });
+
+    Object.defineProperty(context, 'animationDuration', {
+      enumerable: true,
+      get: () => this.animationDuration,
+    });
+
+    Object.defineProperty(context, 'easing', {
+      enumerable: true,
+      get: () => this.easing,
+    });
+
+    Object.defineProperty(context, 'shape', {
+      enumerable: true,
+      get: () => this.shape,
+    });
+
+    return { context };
+  },
   data() {
     return {
       mousePosition: {

--- a/src/components/parallax-element.vue
+++ b/src/components/parallax-element.vue
@@ -8,6 +8,10 @@
 export default {
   name: 'ParallaxElement',
   props: {
+    context: {
+      type: Object,
+      required: true,
+    },
     parallaxStrength: {
       type: Number,
       default: 10,
@@ -22,21 +26,14 @@ export default {
     },
   },
   computed: {
-    parent() {
-      return this.$parent;
-    },
-    isHovering() {
-      return this.parent.isHovering;
-    },
-    mousePosition() {
-      return this.parent.mousePosition;
-    },
     transform() {
-      if (!this.parent.isHovering) return;
-      const shape = this.$el ? this.parent.$el.getBoundingClientRect() : { top: 0, left: 0 };
+      const { isHovering, mousePosition, shape } = this.context;
+
+      if (!isHovering) return;
+
       const parallaxStrength = this.type === 'depth' ? Math.abs(this.parallaxStrength) : this.parallaxStrength;
-      const relativeX = this.mousePosition.x - shape.left;
-      const relativeY = this.mousePosition.y - shape.top;
+      const relativeX = mousePosition.x - shape.left;
+      const relativeY = mousePosition.y - shape.top;
       const movementX = ((relativeX - shape.width / 2) / (shape.width / 2)) * parallaxStrength;
       const movementY = ((relativeY - shape.height / 2) / (shape.height / 2)) * parallaxStrength;
 
@@ -61,13 +58,13 @@ export default {
       };
     },
     transitionDuration() {
-      const { animationDuration } = this.parent;
+      const { animationDuration, didEnter } = this.context;
       const durationException = animationDuration > 400 ? animationDuration : 400;
-      const duration = this.parent.didEnter ? animationDuration : durationException;
+      const duration = didEnter ? animationDuration : durationException;
       return `${duration}ms`;
     },
     transitionTimingFunction() {
-      return this.parent.easing;
+      return this.context.easing;
     },
   },
 };

--- a/src/components/parallax-element.vue
+++ b/src/components/parallax-element.vue
@@ -8,10 +8,6 @@
 export default {
   name: 'ParallaxElement',
   props: {
-    context: {
-      type: Object,
-      required: true,
-    },
     parallaxStrength: {
       type: Number,
       default: 10,
@@ -25,6 +21,7 @@ export default {
       default: 'div',
     },
   },
+  inject: ['context'],
   computed: {
     transform() {
       const { isHovering, mousePosition, shape } = this.context;


### PR DESCRIPTION
Using this.parent is blocking in case a dom element is located between the paralax-container and the paralax-element.

My proposal is about using provide/inject for passing the parent's context to a child.

this time is not breaking change, and always `easy to use`like your mantra

